### PR TITLE
Two new functions to find the nearest hex to a point.

### DIFF
--- a/js/Grid.js
+++ b/js/Grid.js
@@ -133,3 +133,30 @@ HT.Grid.prototype.GetHexById = function(id) {
 	}
 	return null;
 };
+
+/**
+ * Returns the nearest hex to a given point
+ * @this {HT.Grid}
+ * @param {HT.Point} p the test point 
+ * @return {HT.Hexagon}
+ */
+HT.Grid.prototype.GetNearestHex = function(/*Point*/ p) {
+	
+  var distance;
+  var minDistance = Number.MAX_VALUE;
+  var hx = null;
+  
+  // iterate through each hex in the grid
+	for (var h in this.Hexes)
+	{
+    distance = this.Hexes[h].distanceFromMidPoint(p);
+    
+    if (distance < minDistance) // if this is the closest so far
+    {
+      minDistance = distance;
+      hx = this.Hexes[h];
+    }
+	}
+
+	return hx;
+};

--- a/js/HexagonTools.js
+++ b/js/HexagonTools.js
@@ -203,6 +203,21 @@ HT.Hexagon.prototype.Contains = function(/*Point*/ p) {
 	return isIn;
 };
 
+/**
+ * Returns absolute distance in pixels from the mid point of this hex to the given point
+ * @this {HT.Hexagon}
+ * @param {HT.Point} p the test point
+ * @return {number} the distance in pixels
+ */
+HT.Hexagon.prototype.distanceFromMidPoint = function(/*Point*/ p) {
+  // Pythagoras' Theorem: Square of hypotenuse = sum of squares of other two sides
+  var deltaX = this.MidPoint.X - p.X;
+	var deltaY = this.MidPoint.Y - p.Y;
+  
+  // squaring so don't need to worry about rooting a negative number  
+  //return Math.sqrt( (deltaX * deltaX) + (deltaY * deltaY) );
+  return (deltaX * deltaX) + (deltaY * deltaY);
+};
 
 HT.Hexagon.Orientation = {
 	Normal: 0,


### PR DESCRIPTION
I originally posted these functions in a comment on the blog but I thought I ought to pull out my finger and learn how to do it GitHub style...

Here are a couple of functions I added so I could find the closest hex to a click/touch location. This is useful around the edges of a rectangular map where there are "voids" between the whole hexes, particularly on mobile platforms where touch events may be a bit inaccurate. The functions are given freely and without licence so it's OK to edit, discard, deride, steal, butcher or ignore the functions as you see fit. Add 'em to the library if you think they are useful.

There is scope for a couple of optimisations for very large grids:
1. Assuming you don't care about real distances, remove the call to Math.sqrt() and work with the square of the distance. Same result, less cycles.
2. Rather than iterating through the grid from the start you could dive into the middle and do a sort of binary search. The grid would need to record its width/height in hexes when it is created so you could jump over rows/columns. You might even be able to narrow it down directly to 4 (or 2?) hexes with a bit of thought.

I'm currently testing with a grid of 885 hexes and there are no performance issues even on a rubbish mobile.
